### PR TITLE
weechat: added gnutls

### DIFF
--- a/community/weechat/build
+++ b/community/weechat/build
@@ -10,6 +10,7 @@ cmake \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DENABLE_MAN=OFF \
     -DENABLE_DOC=OFF \
-    -DHAVE_GCRYPT=OFF
+    -DHAVE_GCRYPT=OFF \
+    -DENABLE_GNUTLS=ON
 
 make DESTDIR="$1" install

--- a/community/weechat/depends
+++ b/community/weechat/depends
@@ -1,5 +1,5 @@
 cmake     make
+gnutls
 libgcrypt
 libressl
 zlib
-gnutls

--- a/community/weechat/depends
+++ b/community/weechat/depends
@@ -2,3 +2,4 @@ cmake     make
 libgcrypt
 libressl
 zlib
+gnutls


### PR DESCRIPTION
Sadly WeeChat requires GnuTLS for SSL/TLS connections.

This PR adds GnuTLS to WeeChat.