### PR TITLE
emacs fix: use with-xpm=no

### DIFF
--- a/community/emacs/build
+++ b/community/emacs/build
@@ -8,7 +8,8 @@
     --without-toolkit-scroll-bars \
     --without-dbus \
     --without-gconf \
-    --without-gsettings
+    --without-gsettings \
+    --with-xpm=no
 
 mkdir -p "$1/usr/share/emacs/site-lisp"
 cat << EOF > "$1/usr/share/emacs/site-lisp/site-start.el"


### PR DESCRIPTION
## Description of package
@dylanaraps I dropped the ball on this. Our Emacs won't build as is currently unleess we add this configure option.
## Checklist

- [x] Latest upstream version.
- [x] I agree to maintain this package (**required**).
- [x] I agree to notify KISS if I can no longer maintain this package (**required**).
