### PR TITLE
libxdg-basedir: use automake

### DIFF
--- a/community/libxdg-basedir/build
+++ b/community/libxdg-basedir/build
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+autoreconf -fi
+
 ./configure \
     --prefix=/usr \
     --enable-unicode-properties \

--- a/community/libxdg-basedir/depends
+++ b/community/libxdg-basedir/depends
@@ -1,0 +1,2 @@
+automake make
+libtool  make


### PR DESCRIPTION
## Rationale

Turns out this package's source *does* need to generate `./configure` from automake, to make matters worse, last release was in 2012.

## Checklist

- [x] Latest upstream version.
- [ ] I agree to maintain this package (**required**). Ping maintainer @a-schaefers 
- [ ] I agree to notify KISS if I can no longer maintain this package (**required**).
