### PR TITLE
Improve emacs-nox security settings, add better default xterm settings

### DIFF
--- a/community/emacs-nox/build
+++ b/community/emacs-nox/build
@@ -29,21 +29,7 @@ cat << EOF > "$1/usr/share/emacs/site-lisp/site-start.el"
 ;; Better defaults when inside an X11 terminal
 (when (getenv "DISPLAY")
   ;; Enable X11 mouse features
-  (xterm-mouse-mode 1)
-
-  ;; Use xsel and the X11 clipboard
-  (when (executable-find "xsel")
-    (setq x-select-enable-clipboard t)
-    (defun xsel-cut-function (text &optional push)
-      (with-temp-buffer
-        (insert text)
-        (call-process-region (point-min) (point-max) "xsel" nil 0 nil "--clipboard" "--input")))
-    (defun xsel-paste-function()
-      (let ((xsel-output (shell-command-to-string "xsel --clipboard --output")))
-        (unless (string= (car kill-ring) xsel-output)
-          xsel-output )))
-    (setq interprogram-cut-function 'xsel-cut-function)
-    (setq interprogram-paste-function 'xsel-paste-function)))
+  (xterm-mouse-mode 1))
 EOF
 
 make

--- a/community/emacs-nox/build
+++ b/community/emacs-nox/build
@@ -12,6 +12,10 @@
 
 mkdir -p "$1/usr/share/emacs/site-lisp"
 cat << EOF > "$1/usr/share/emacs/site-lisp/site-start.el"
+;; Improve startup time
+(setq gc-cons-threshold 50000000
+      package-enable-at-startup nil)
+
 ;; Fix ugly
 (menu-bar-mode -1)
 

--- a/community/emacs-nox/build
+++ b/community/emacs-nox/build
@@ -6,12 +6,40 @@
     --without-all \
     --without-x \
     --with-x-toolkit=no \
-    --with-x=no
+    --with-x=no \
+    --with-gnutls=yes \
+    --with-xml2=yes
 
 mkdir -p "$1/usr/share/emacs/site-lisp"
 cat << EOF > "$1/usr/share/emacs/site-lisp/site-start.el"
-;; fix ugly
+;; Fix ugly
 (menu-bar-mode -1)
+
+;; Better security defaults
+(with-eval-after-load 'gnutls
+  (setq
+   gnutls-verify-error t
+   gnutls-min-prime-bits 2048
+   gnutls-trustfiles '("/etc/ssl/cert.pem")))
+
+;; Better defaults when inside an X11 terminal
+(when (getenv "DISPLAY")
+  ;; Enable X11 mouse features
+  (xterm-mouse-mode 1)
+
+  ;; Use xsel and the X11 clipboard
+  (when (executable-find "xsel")
+    (setq x-select-enable-clipboard t)
+    (defun xsel-cut-function (text &optional push)
+      (with-temp-buffer
+        (insert text)
+        (call-process-region (point-min) (point-max) "xsel" nil 0 nil "--clipboard" "--input")))
+    (defun xsel-paste-function()
+      (let ((xsel-output (shell-command-to-string "xsel --clipboard --output")))
+        (unless (string= (car kill-ring) xsel-output)
+          xsel-output )))
+    (setq interprogram-cut-function 'xsel-cut-function)
+    (setq interprogram-paste-function 'xsel-paste-function)))
 EOF
 
 make

--- a/community/emacs-nox/depends
+++ b/community/emacs-nox/depends
@@ -1,3 +1,5 @@
 zlib
 xz
 ncurses
+gnutls
+libxml2


### PR DESCRIPTION
## Description of package
1. I have spent a lot of time trying to understand the current Emacs security situation, and to the best of my understanding, Emacs development teams favor gnutls to be the default tls, and all other implementations inside Emacs have now gone unmaintained (probably due to being non-gpl licensed), and coming up in Emacs 27 this will be the case even more so. I'm ensuring that our Emacs builds are building explicitly with gnutls support.

2. I also enabled mouse clicking support when using an X11 terminal emulator

3. I enabled libxml2 support for emacs-nox, which will allow use of the eww web browser, which is very nice for reading documentation directly in the Emacs editor.

4. Improve startup times by ~1 second by decreasing garbage collection frequency to every 50 MB instead of the default 0.76MB (Emacs is optimized for very old computers by default) AND by toggling off package.el (can be turned back on by the user easily, no point in penalizing all Emacs users with a slow startup by having using package.el by always-on by default...) 

## Checklist
## Checklist

- [x] Latest upstream version.

- [x] Latest upstream version.
- [x] I agree to maintain this package (**required**).
- [x] I agree to notify KISS if I can no longer maintain this package (**required**).
