### PR TITLE
improve emacs' gnutls settings

### DIFF
--- a/community/emacs/build
+++ b/community/emacs/build
@@ -9,17 +9,25 @@
     --without-dbus \
     --without-gconf \
     --without-gsettings \
-    --with-xpm=no
+    --with-xpm=no \
+    --with-gnutls=yes
 
 mkdir -p "$1/usr/share/emacs/site-lisp"
 cat << EOF > "$1/usr/share/emacs/site-lisp/site-start.el"
-;; fix ugly
+;; Fix ugly
 (menu-bar-mode -1)
 (tool-bar-mode -1)
 (scroll-bar-mode -1)
 (horizontal-scroll-bar-mode -1)
 
-;; needed unless kiss linux gets librsvg support
+;; Better security defaults
+(with-eval-after-load 'gnutls
+  (setq
+   gnutls-verify-error t
+   gnutls-min-prime-bits 2048
+   gnutls-trustfiles '("/etc/ssl/cert.pem")))
+
+;; Needed unless KISS Linux gains librsvg support
 (setq-default shr-blocked-images ".*\.svg$")
 EOF
 

--- a/community/emacs/build
+++ b/community/emacs/build
@@ -14,6 +14,10 @@
 
 mkdir -p "$1/usr/share/emacs/site-lisp"
 cat << EOF > "$1/usr/share/emacs/site-lisp/site-start.el"
+;; Improve startup time
+(setq gc-cons-threshold 50000000
+      package-enable-at-startup nil)
+
 ;; Fix ugly
 (menu-bar-mode -1)
 (tool-bar-mode -1)


### PR DESCRIPTION
## Description of package
1. I have spent a lot of time trying to understand the current Emacs security situation, and to the best of my understanding, Emacs development teams favor gnutls to be the default tls, and all other implementations inside Emacs have now gone unmaintained (probably due to being non-gpl licensed), and coming up in Emacs 27 this will be the case even more so. I'm ensuring that our Emacs builds are building explicitly with gnutls support.

2. Improve startup times by ~1 second by decreasing garbage collection frequency to every 50 MB instead of the default 0.76MB (Emacs is optimized for very old computers by default) AND by toggling off package.el (can be turned back on by the user easily, no point in penalizing all Emacs users with a slow startup by having using package.el by always-on by default...) 

## Checklist

- [x] Latest upstream version.
- [x] I agree to maintain this package (**required**).
- [x] I agree to notify KISS if I can no longer maintain this package (**required**).
