### PR TITLE
webkit2gtk: add libXt as dep

### DIFF
--- a/community/webkit2gtk/depends
+++ b/community/webkit2gtk/depends
@@ -5,6 +5,7 @@ cmake  make
 gperf  make
 harfbuzz-icu
 libXslt
+libXt
 libgcrypt
 libsoup
 libwebp


### PR DESCRIPTION
## Issue
Compiling `webkit2gtk` on a fresh kiss install complains about `libXt` not present.

## Solution
Add `libXt` as dep
