### PR TITLE
sbase: respect environmental vars, fix static linking

### DIFF
--- a/community/sbase/build
+++ b/community/sbase/build
@@ -1,6 +1,11 @@
 #!/bin/sh -e
 
-make CFLAGS="$CFLAGS -static" sbase-box
+# prepend environment to config.mk defs
+sed -i config.mk \
+    -e "/^CFLAGS/s/=/= $CFLAGS -static/" \
+    -e "/^LDFLAGS/s/=/= $LDFLAGS -static/"
+
+make sbase-box
 make DESTDIR="$1" PREFIX=/usr sbase-box-install
 
 # Remove 'tar'/'sed' which won't work with kiss.


### PR DESCRIPTION
`file /usr/bin/sbase-box` indicated dynamic linking. this is a fix, also properly respecting environmental flags (though overridden by the defaults in config.mk).
