### PR TITLE
fff: fix depends, file is missing

### DIFF
--- a/community/fff/depends
+++ b/community/fff/depends
@@ -1,1 +1,2 @@
 bash
+file


### PR DESCRIPTION
## Issue
Can't open files by pressing `Return`

## Solution
  - `file` is missing as dep, installed it solved the issue.
  - `file` added in `depends`