### PR TITLE
gnupg2: Keep --enable-gpg-is-gpg2, Add gpg symlinks sans "2" for alternatives

### DIFF
--- a/community/gnupg2/build
+++ b/community/gnupg2/build
@@ -10,3 +10,6 @@
 
 make
 make DESTDIR="$1" install
+
+ln -s /usr/bin/gpg2 "$1/usr/bin/gpg"
+ln -s /usr/bin/gpgv2 "$1/usr/bin/gpgv"


### PR DESCRIPTION
## Description of package

## Checklist

- [ ] Latest upstream version.
- [ ] I agree to maintain this package (**required**).
- [ ] I agree to notify KISS if I can no longer maintain this package (**required**).
