### PR TITLE
tcl: fix build

### DIFF
--- a/community/tcl/build
+++ b/community/tcl/build
@@ -2,6 +2,8 @@
 
 IFS=. read -r maj min _ < "${0%/*}/version"
 
+rm -rf pkgs/sqlite3*
+
 unix/configure \
     --prefix=/usr \
     --mandir=/usr/share/man \
@@ -14,4 +16,4 @@ make INSTALL_ROOT="$1" install install-private-headers
 
 ln -s "/usr/bin/tclsh${maj}.${min}" "$1/usr/bin/tclsh"
 ln -s "/usr/lib/libtcl${maj}.${min}.so" "$1/usr/lib/libtcl.so"
-install -Dm644 tcl.m4 -t "$1/usr/share/aclocal"
+install -Dm644 unix/tcl.m4 -t "$1/usr/share/aclocal"


### PR DESCRIPTION
when `--with-system-sqlite` is specified, the build fails when linking `tclsqlite.c` with a bunch of undefined references. deleting `pkgs/sqlite3*` fixes this.
 
## Existing package

- [ ] I am the maintainer of this package.
