### PR TITLE
gdb: fix build

### DIFF
--- a/community/gdb/build
+++ b/community/gdb/build
@@ -8,7 +8,10 @@ EOF
 chmod +x makeinfo
 export PATH=$PATH:$PWD
 
-./configure \
+mkdir _build
+cd _build
+
+../configure \
     --prefix=/usr \
     --without-installed-readline \
     --disable-nls


### PR DESCRIPTION
gdb 9.1 needs a separate build directory, apparently -- it refuses to
build from the source dir. To fix this, I've created a `_build` dir
(since `build` already exists). This should hopefully cause no problems.