### PR TITLE
Fix build: disable OpenGL support

### DIFF
--- a/community/dosbox/build
+++ b/community/dosbox/build
@@ -1,7 +1,8 @@
 #!/bin/sh -e
 
 ./configure \
-    --prefix=/usr
+    --prefix=/usr \
+    --disable-opengl
 
 make
 make DESTDIR="$1" install


### PR DESCRIPTION
Read: https://k1ss.org/guidestones.txt

## Description of package
Reason for change:
I found Dosbox fails to build while testing out on a clean install.  I had "libglu" installed on my machine after working on something else.  libglu is needed by Dosbox, unless --disable-opengl is specified.

I have libglu ready to add to the repo if required, but since Dosbox can do without it (and didn't seem to run any slower without it when I tried), I thought it would be preferable to avoid a new dependency if it's not essential.

- [x] I am the maintainer of this package.
