### PR TITLE
mpd: require boost as a make dependency

### DIFF
--- a/community/mpd/depends
+++ b/community/mpd/depends
@@ -1,2 +1,2 @@
-boost
+boost make
 meson make


### PR DESCRIPTION
Since boost is linked statically, mpd does not require it as a runtime dependency. Thanks a lot to @ioraff for pointing this out.

## Existing package

- [X] I am the maintainer of this package.
