### PR TITLE
tcc: use CC as compiler

### DIFF
--- a/community/tcc/build
+++ b/community/tcc/build
@@ -2,6 +2,7 @@
 
 ./configure \
     --prefix=/usr \
+    --cc="${CC:-cc}" \
     --config-musl
 
 make


### PR DESCRIPTION
tcc's configure uses gcc as default compiler.

Allow user choice of c compiler using CC environment variable (tcc can compile itself).

## Existing package

- [x] I am the maintainer of this package.
