### PR TITLE
boost: don't link statically

### DIFF
--- a/community/boost/build
+++ b/community/boost/build
@@ -1,5 +1,5 @@
 #!/bin/sh -e
 
 ./bootstrap.sh --prefix="$1/usr"
-./b2 stage threading=multi link=shared
-./b2 install threading=multi link=shared
+./b2 stage threading=multi
+./b2 install threading=multi

--- a/community/boost/build
+++ b/community/boost/build
@@ -1,5 +1,5 @@
 #!/bin/sh -e
 
 ./bootstrap.sh --prefix="$1/usr"
-./b2 stage threading=multi link=static
-./b2 install threading=multi link=static
+./b2 stage threading=multi link=shared
+./b2 install threading=multi link=shared


### PR DESCRIPTION
Fixes #524 . Manifest pasted on termbin for being too big.

See <https://termbin.com/g867>

- [X] I am the maintainer of this package