### PR TITLE
wireguard-tools: remove unnecessary build flags

### DIFF
--- a/community/wireguard-tools/build
+++ b/community/wireguard-tools/build
@@ -3,10 +3,4 @@
 cd src
 
 make
-make \
-    DESTDIR="$1" \
-    PREFIX=/usr \
-    WITH_BASHCOMPLETION=no \
-    WITH_WGQUICK=no \
-    WITH_SYSTEMDUNITS=no \
-    install
+make DESTDIR="$1" PREFIX=/usr install


### PR DESCRIPTION
Makefile will now install wg-quick if it finds bash on the system.

## Existing package

- [x] I am the maintainer of this package.
