### PR TITLE
Fixed --sysconfdir in nano build options. Now set to /etc.

### DIFF
--- a/community/nano/build
+++ b/community/nano/build
@@ -1,7 +1,8 @@
 #!/bin/sh -e
 
 ./configure \
-    --prefix=/usr
+    --prefix=/usr \
+    --sysconfdir=/etc
 
 make
 make DESTDIR="$1" install


### PR DESCRIPTION
Please fill out the template.

Read: https://k1ss.org/style
Read: https://k1ss.org/guidestones

---

## Description of package


## Installed manifest of package

(`cat /var/db/kiss/installed/<pkg_name>/manifest`)

```
MANIFEST HERE
```

## New package

- [ ] Latest upstream version.
- [ ] I agree to maintain this package.
- [ ] I agree to notify @dylanaraps if I can no longer maintain this package.

## Existing package

- [x] I am the maintainer of this package.
