### PR TITLE
mpd-libmpdclient: fix circular dependency

### DIFF
--- a/community/libmpdclient/depends
+++ b/community/libmpdclient/depends
@@ -1,2 +1,1 @@
 meson make
-mpd

--- a/community/mpd/build
+++ b/community/mpd/build
@@ -6,6 +6,7 @@ meson \
     --prefix=/usr \
     --sysconfdir=/etc \
     --localstatedir=/var \
+    -Dlibmpdclient=disabled \
     . output
 
 ninja -C output


### PR DESCRIPTION
Resolves #756

There isn't actually a circular dependency between `mpd` and
`libmpdclient`. It seems that `libmpdclient` doesn't actually
depend on `mpd`. Changes here make sure that neither of them
depend on each other by,

* Setting an option in meson build for mpd to disable linking to libmpdclient.
* Removing the listed mpd dependency from libmpdclient.

Manifests are the same as previous.

## Existing package

- [x] I am the maintainer of this package.