### PR TITLE
gstreamer gst-plugins: add missing dependencies

### DIFF
--- a/community/gst-plugins/depends
+++ b/community/gst-plugins/depends
@@ -13,7 +13,7 @@ libsoup
 libvorbis
 libvpx
 libwebp
-linux-headers
+linux-headers make
 meson make
 opus
 pango

--- a/community/gst-plugins/depends
+++ b/community/gst-plugins/depends
@@ -13,6 +13,7 @@ libsoup
 libvorbis
 libvpx
 libwebp
+linux-headers
 meson make
 opus
 pango

--- a/community/gstreamer/depends
+++ b/community/gstreamer/depends
@@ -1,2 +1,3 @@
+bison make
 glib
 meson make


### PR DESCRIPTION
This resolves #774 . No manifest change is made.

Also, I have noticed that gst-plugins depend on linux-headers. So I have
added that as well.