### PR TITLE
sbase: do not unlink tar

### DIFF
--- a/community/sbase/build
+++ b/community/sbase/build
@@ -8,6 +8,5 @@ sed -i \
 make sbase-box
 make DESTDIR="$1" PREFIX=/usr sbase-box-install
 
-# Remove 'tar'/'sed' which won't work with kiss.
-unlink "$1/usr/bin/tar"
+# Unlink sed, because '-i' is widely used
 unlink "$1/usr/bin/sed"


### PR DESCRIPTION
## Description of package

We no longer need to unlink sbase-tar.


## Existing package

- [x] I am the maintainer of this package.