### PR TITLE
boost: add missing linux-headers dependency

### DIFF
--- a/community/boost/depends
+++ b/community/boost/depends
@@ -1,0 +1,1 @@
+linux-headers make


### PR DESCRIPTION
## Existing package

- [x] I am the maintainer of this package.