### PR TITLE
qt5{-webengine} updated deps

### DIFF
--- a/community/qt5-webengine/depends
+++ b/community/qt5-webengine/depends
@@ -12,6 +12,7 @@ libXtst
 libdrm
 libevent
 libxml2
+linux-headers make
 nss
 python2 make
 qt5

--- a/community/qt5/depends
+++ b/community/qt5/depends
@@ -10,6 +10,7 @@ libXext
 libinput
 libjpeg-turbo
 libpng
+linux-headers make
 mesa
 mtdev
 perl  make


### PR DESCRIPTION
qt5 and qt5-webengine require linux-headers to make.

## Existing package

- [x] I am the maintainer of this package.
