### PR TITLE
bspwm: fix gcc 10 (Untested on GCC)

### DIFF
--- a/community/bspwm/build
+++ b/community/bspwm/build
@@ -1,4 +1,6 @@
 #!/bin/sh -e
 
+export CFLAGS="$CFLAGS -fcommon"
+
 make PREFIX=/usr
 make DESTDIR="$1" PREFIX=/usr install


### PR DESCRIPTION
I can't confirm the current problem since I don't use GCC, but if sxhkd is affected, then bspwm might be affected too. Dylan, can you check if the current packaging without CFLAGS fix work? If it works, then you can close this PR without merging. Thanks.

## Installed manifest of package

No changes.

## Existing package

- [x] I am the maintainer of this package.
