### PR TITLE
ii: fix permissions

### DIFF
--- a/community/ii/build
+++ b/community/ii/build
@@ -1,4 +1,6 @@
 #!/bin/sh -e
 
+sed -i 's/775/755/g' Makefile
+
 make
 make DESTDIR="$1" PREFIX=/usr install


### PR DESCRIPTION
## Description of changes

Fixes /usr/bin/ii permissions from 775 to 755

## Installed manifest of package

```
/var/db/kiss/installed/ii/version
/var/db/kiss/installed/ii/sources
/var/db/kiss/installed/ii/manifest
/var/db/kiss/installed/ii/checksums
/var/db/kiss/installed/ii/build
/var/db/kiss/installed/ii/
/var/db/kiss/installed/
/var/db/kiss/
/var/db/
/var/
/usr/share/man/man1/ii.1
/usr/share/man/man1/
/usr/share/man/
/usr/share/doc/ii/README
/usr/share/doc/ii/LICENSE
/usr/share/doc/ii/FAQ
/usr/share/doc/ii/CHANGES
/usr/share/doc/ii/
/usr/share/doc/
/usr/share/
/usr/bin/ii
/usr/bin/
/usr/
```

## Existing package

- [x] I am the maintainer of this package.
