### PR TITLE
sbase: proper static linking

### DIFF
--- a/community/sbase/build
+++ b/community/sbase/build
@@ -3,13 +3,11 @@
 # Make sbase tar accept arguments without dash
 patch -p1 < tar-dash-remove.patch
 
-sed -i \
-    -e "/^CFLAGS/s/=/= $CFLAGS -static/" \
-    -e "/^LDFLAGS/s/=/= $LDFLAGS -static/" \
-    config.mk
-
-make sbase-box
-make DESTDIR="$1" PREFIX=/usr sbase-box-install
+make \
+    DESTDIR="$1" \
+    PREFIX=/usr \
+    LDFLAGS="$LDFLAGS -static" \
+    sbase-box-install
 
 # Unlink sed, because '-i' is widely used
 unlink "$1/usr/bin/sed"


### PR DESCRIPTION
These changes don't make a difference in the manifest. The sed call to `config.mk` was unnecessary.

The issue was with the Makefile. It rebuilds sbase-box when running `sbase-box-install`. Since we do not normally add LDFLAGS to the `install` part, the outcome wasn't a static binary.

I am also sending a patch to the mailing-list fixing this issue, so if the patch is accepted, I will be reverting to the clean-looking format.

```
make sbase-box
make sbase-box-install
```