### PR TITLE
qt5 requires icu

### DIFF
--- a/community/qt5/depends
+++ b/community/qt5/depends
@@ -2,6 +2,7 @@ bison make
 flex  make
 freetype-harfbuzz
 gperf make
+icu
 libICE
 libSM
 libX11


### PR DESCRIPTION

`qt5` requires `icu` until the (forthcoming) bug report with upstream is resolved. 

Closes #972 

## Existing package

- [x] I am the maintainer of this package.
