### PR TITLE
qt5 no longer requires icu

### DIFF
--- a/community/qt5/depends
+++ b/community/qt5/depends
@@ -2,7 +2,6 @@ bison make
 flex  make
 freetype-harfbuzz
 gperf make
-icu
 libICE
 libSM
 libX11
@@ -23,6 +22,6 @@ sqlite
 xcb-util
 xcb-util-image
 xcb-util-keysyms
-xcb-util-wm
 xcb-util-renderutil
+xcb-util-wm
 zlib


### PR DESCRIPTION
As per the resolution of [this](https://bugreports.qt.io/browse/QTBUG-85453) bug report, `qt5` only required `icu` because `kiss` set `LC_ALL=C`. As this change has been reverted, we can revert our `icu` requirement.

## Existing package

- [x] I am the maintainer of this package.
