### PR TITLE
fftw: undo change to build flags (breaks deps)

### DIFF
--- a/community/fftw/build
+++ b/community/fftw/build
@@ -3,8 +3,7 @@
 ./configure \
     --prefix=/usr \
     --enable-shared \
-    --enable-threads \
-    --enable-float
+    --enable-threads
 
 make
 make DESTDIR="$1" install


### PR DESCRIPTION
Change made the names of library files change, breaking dependencies. 

## Existing package

- [Y] I am the maintainer of this package.
