### PR TITLE
uemacs: add missing dependency and build statically

### DIFF
--- a/community/uemacs/build
+++ b/community/uemacs/build
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-make
+make LDFLAGS="$LDFLAGS -static" LIBS=-lncursesw
 
 install -Dm755 -t "$1/usr/bin" em
 install -Dm644 -t "$1/usr/share/uemacs" emacs.hlp emacs.rc

--- a/community/uemacs/depends
+++ b/community/uemacs/depends
@@ -1,0 +1,1 @@
+ncurses make


### PR DESCRIPTION
This change increases the size of em ~40KB. I have also forgotten to add ncurses as a dependency. Since we are now building statically, ncurses is a make dependency here.

## Existing package

- [x] I am the maintainer of this package.
