### PR TITLE
mksh: added 'lksh' as part of 'mksh'

### DIFF
--- a/community/mksh/build
+++ b/community/mksh/build
@@ -1,5 +1,23 @@
 #!/bin/sh -e
 
-CFLAGS="$CFLAGS -static" sh Build.sh
+export  CFLAGS="$CFLAGS  -static"
+export LDFLAGS="$LDFLAGS -static"
 
-install -Dm755 "mksh" "$1/usr/bin/mksh"
+mkdir -p lksh "$1/usr/bin" "$1/usr/share/man/man1/"
+
+# Enable parallel mode if the processor is multi-core.
+[ "$(nproc)" -gt 1 ] && parallel=-j
+
+# Build 'mksh' shell.
+sh Build.sh -Q -r $parallel
+
+# Build 'lksh' shell.
+cd lksh
+export CPPFLAGS="$CPPFLAGS -DMKSH_BINSHPOSIX -DMKSH_BINSHREDUCED"
+sh ../Build.sh -L -Q -r $parallel
+cd ..
+
+ln      -s     lksh          "$1/usr/bin/sh"
+install -Dm555 mksh          "$1/usr/bin/mksh"
+install -Dm555 lksh/lksh     "$1/usr/bin/lksh"
+install -Dm444 lksh.1 mksh.1 "$1/usr/share/man/man1/"

--- a/community/mksh/build
+++ b/community/mksh/build
@@ -12,10 +12,11 @@ mkdir -p lksh "$1/usr/bin" "$1/usr/share/man/man1/"
 sh Build.sh -Q -r $parallel
 
 # Build 'lksh' shell.
+(
 cd lksh
 export CPPFLAGS="$CPPFLAGS -DMKSH_BINSHPOSIX -DMKSH_BINSHREDUCED"
 sh ../Build.sh -L -Q -r $parallel
-cd ..
+)
 
 ln      -s     lksh          "$1/usr/bin/sh"
 install -Dm555 mksh          "$1/usr/bin/mksh"

--- a/community/mksh/post-install
+++ b/community/mksh/post-install
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+
+shell=/usr/bin/mksh
+grep -qx "$shell" /etc/shells || {
+	echo "Adding '$shell' to '/etc/shells'."
+	echo "$shell" >>/etc/shells
+}

--- a/community/mksh/pre-remove
+++ b/community/mksh/pre-remove
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+sed -e '/^\/usr\/bin\/mksh$/d' -i /etc/shells


### PR DESCRIPTION
## Description of package
`lksh` purpose is to run legacy sh scripts and POSIX sh scripts (see [Building lksh](http://www.mirbsd.org/mksh.htm#build) and [lksh.1](https://man.voidlinux.org/lksh.1))

In addition to `lksh` itself, also added:
* enable parallel compiling if processor is multi-core
* hooks to add `mksh` to `/etc/shells`
* symlink `/bin/sh -> lksh`

## Installed manifest of package
```
/var/db/kiss/installed/mksh/version
/var/db/kiss/installed/mksh/sources
/var/db/kiss/installed/mksh/pre-remove
/var/db/kiss/installed/mksh/post-install
/var/db/kiss/installed/mksh/manifest
/var/db/kiss/installed/mksh/checksums
/var/db/kiss/installed/mksh/build
/var/db/kiss/installed/mksh/
/var/db/kiss/installed/
/var/db/kiss/choices/mksh>usr>bin>sh
/var/db/kiss/choices/
/var/db/kiss/
/var/db/
/var/
/usr/share/man/man1/mksh.1
/usr/share/man/man1/lksh.1
/usr/share/man/man1/
/usr/share/man/
/usr/share/
/usr/bin/mksh
/usr/bin/lksh
/usr/bin/
/usr/
```

## Existing package
Maintainer: @a-schaefers 
