### PR TITLE
qt5-webengine now builds with latest bison

### DIFF
--- a/community/qt5-webengine/build
+++ b/community/qt5-webengine/build
@@ -4,6 +4,10 @@ for patch in *.patch; do
     patch -p1 < "$patch"
 done
 
+# Fix a build error introduced with bison 3.7
+sed -i '/os.unlink(outputHTmp)/d' \
+    src/3rdparty/chromium/third_party/blink/renderer/build/scripts/rule_bison.py
+
 # Remove dbus dependency.
 {
     sed -i 's/dbus//g' \


### PR DESCRIPTION
This PR fixes a build error introduced with the latest version of `bison` (3.7+). 
---

## Installed manifest of package

(`cat /var/db/kiss/installed/<pkg_name>/manifest`)

```
http://ix.io/2t4d
```

## Existing package

- [x] I am the maintainer of this package.
