### PR TITLE
qt5-x11extras has perl make dep

### DIFF
--- a/community/qt5-x11extras/depends
+++ b/community/qt5-x11extras/depends
@@ -1,1 +1,2 @@
+perl make
 qt5


### PR DESCRIPTION
`qt5-x11extras` requires `perl` at build time.


## Existing package

- [x] I am the maintainer of this package.
