### PR TITLE
usbutils: fix missing slash in sed

### DIFF
--- a/community/usbutils/build
+++ b/community/usbutils/build
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-sed -i 's/bash/sh' usbhid-dump/bootstrap
+sed -i 's/bash/sh/' usbhid-dump/bootstrap
 
 ./autogen.sh
 


### PR DESCRIPTION
## Installed manifest of package

No differences.

## Existing package

- [X] I am the maintainer of this package.

Closes #1100.