### PR TITLE
emacs-nox: track the main emacs package for version and sources

### DIFF
--- a/community/emacs-nox/checksums
+++ b/community/emacs-nox/checksums
@@ -1,1 +1,1 @@
-4d90e6751ad8967822c6e092db07466b9d383ef1653feb2f95c93e7de66d3485  emacs-26.3.tar.xz
+../emacs/checksums

--- a/community/emacs-nox/sources
+++ b/community/emacs-nox/sources
@@ -1,1 +1,1 @@
-https://ftp.gnu.org/gnu/emacs/emacs-26.3.tar.xz
+../emacs/sources

--- a/community/emacs-nox/version
+++ b/community/emacs-nox/version
@@ -1,1 +1,1 @@
-26.3 1 
+../emacs/version


### PR DESCRIPTION
I have noticed that the emacs-nox package was outdated. Since emacs-nox is emacs with no X support, I have thought that it is best to just make the {sources,checksums,version} files to be symbolic links to the main emacs package.

- [x] I am the maintainer of this package.