### PR TITLE
nettle: enable static libraries

### DIFF
--- a/community/nettle/build
+++ b/community/nettle/build
@@ -3,7 +3,7 @@
 ./configure \
     --prefix=/usr \
     --enable-shared \
-    --disable-static \
+    --enable-static \
     --enable-mini-gmp \
     --disable-documentation
 


### PR DESCRIPTION
## Installed manifest of package

(`kiss manifest <pkg>`)

```
/var/db/kiss/installed/nettle/version
/var/db/kiss/installed/nettle/sources
/var/db/kiss/installed/nettle/manifest
/var/db/kiss/installed/nettle/depends
/var/db/kiss/installed/nettle/checksums
/var/db/kiss/installed/nettle/build
/var/db/kiss/installed/nettle/
/var/db/kiss/installed/
/var/db/kiss/
/var/db/
/var/
/usr/lib/pkgconfig/nettle.pc
/usr/lib/pkgconfig/hogweed.pc
/usr/lib/pkgconfig/
/usr/lib/libnettle.so.8.0
/usr/lib/libnettle.so.8
/usr/lib/libnettle.so
/usr/lib/libnettle.a
/usr/lib/libhogweed.so.6.0
/usr/lib/libhogweed.so.6
/usr/lib/libhogweed.so
/usr/lib/libhogweed.a
/usr/lib/
/usr/include/nettle/yarrow.h
/usr/include/nettle/xts.h
/usr/include/nettle/version.h
/usr/include/nettle/umac.h
/usr/include/nettle/twofish.h
/usr/include/nettle/siv-cmac.h
/usr/include/nettle/sha3.h
/usr/include/nettle/sha2.h
/usr/include/nettle/sha1.h
/usr/include/nettle/sha.h
/usr/include/nettle/sexp.h
/usr/include/nettle/serpent.h
/usr/include/nettle/salsa20.h
/usr/include/nettle/rsa.h
/usr/include/nettle/ripemd160.h
/usr/include/nettle/realloc.h
/usr/include/nettle/pss.h
/usr/include/nettle/pss-mgf1.h
/usr/include/nettle/poly1305.h
/usr/include/nettle/pkcs1.h
/usr/include/nettle/pgp.h
/usr/include/nettle/pbkdf2.h
/usr/include/nettle/nettle-types.h
/usr/include/nettle/nettle-meta.h
/usr/include/nettle/mini-gmp.h
/usr/include/nettle/memxor.h
/usr/include/nettle/memops.h
/usr/include/nettle/md5.h
/usr/include/nettle/md5-compat.h
/usr/include/nettle/md4.h
/usr/include/nettle/md2.h
/usr/include/nettle/macros.h
/usr/include/nettle/knuth-lfib.h
/usr/include/nettle/hmac.h
/usr/include/nettle/hkdf.h
/usr/include/nettle/gosthash94.h
/usr/include/nettle/gostdsa.h
/usr/include/nettle/gcm.h
/usr/include/nettle/eddsa.h
/usr/include/nettle/ecdsa.h
/usr/include/nettle/ecc.h
/usr/include/nettle/ecc-curve.h
/usr/include/nettle/eax.h
/usr/include/nettle/dsa.h
/usr/include/nettle/dsa-compat.h
/usr/include/nettle/des.h
/usr/include/nettle/curve448.h
/usr/include/nettle/curve25519.h
/usr/include/nettle/ctr.h
/usr/include/nettle/cmac.h
/usr/include/nettle/chacha.h
/usr/include/nettle/chacha-poly1305.h
/usr/include/nettle/cfb.h
/usr/include/nettle/ccm.h
/usr/include/nettle/cbc.h
/usr/include/nettle/cast128.h
/usr/include/nettle/camellia.h
/usr/include/nettle/buffer.h
/usr/include/nettle/blowfish.h
/usr/include/nettle/bignum.h
/usr/include/nettle/base64.h
/usr/include/nettle/base16.h
/usr/include/nettle/asn1.h
/usr/include/nettle/arctwo.h
/usr/include/nettle/arcfour.h
/usr/include/nettle/aes.h
/usr/include/nettle/
/usr/include/
/usr/bin/sexp-conv
/usr/bin/pkcs1-conv
/usr/bin/nettle-pbkdf2
/usr/bin/nettle-lfib-stream
/usr/bin/nettle-hash
/usr/bin/
/usr/
```

## Existing package

- [x] I am the maintainer of this package.
