### PR TITLE
iproute2: enforce --prefix/usr and fix build on clang only systems

### DIFF
--- a/community/iproute2/build
+++ b/community/iproute2/build
@@ -2,7 +2,13 @@
 
 patch -p1 < 0001-make-iproute2-fhs-compliant.patch
 
-./configure
+# Fix hardcoded `gcc` ( there is HOST_CC := $(CC) on line after this,
+# but upstream seems to use it inconsistently ). Otherwise build fails on
+# `clang` based systems with no `gcc` installed.
+sed -i 's/CC := gcc/CC ?= gcc/' Makefile
+
+./configure \
+    --prefix=/usr
 
 make
 make DESTDIR="$1" SBINDIR="/usr/bin" install


### PR DESCRIPTION
`iproute2`'s makefile uses hardcoded `gcc` in one place even if it should use at least `$CC`. if gcc is installed you get a frankenbuild with mixed `$CC` ( clang ) and `gcc`. This change fixes this.

## Existing package

- [x] I am the maintainer of this package.
