### PR TITLE
pciutils: build and install shared libraries

### DIFF
--- a/community/pciutils/build
+++ b/community/pciutils/build
@@ -12,4 +12,6 @@ mk() {
 }
 
 mk
-mk DESTDIR="$1" install install-lib
+mk SHARED=yes
+mk DESTDIR="$1" install    install-lib
+mk DESTDIR="$1" SHARED=yes install-lib


### PR DESCRIPTION
Build and install shared libraries as well. Closes #1233 

## Installed manifest of package

(`kiss manifest <pkg>`)

```
/var/db/kiss/installed/pciutils/version
/var/db/kiss/installed/pciutils/sources
/var/db/kiss/installed/pciutils/manifest
/var/db/kiss/installed/pciutils/depends
/var/db/kiss/installed/pciutils/checksums
/var/db/kiss/installed/pciutils/build
/var/db/kiss/installed/pciutils/
/var/db/kiss/installed/
/var/db/kiss/choices/pciutils>usr>bin>lspci
/var/db/kiss/choices/
/var/db/kiss/
/var/db/
/var/
/usr/share/man/man8/update-pciids.8
/usr/share/man/man8/setpci.8
/usr/share/man/man8/lspci.8
/usr/share/man/man8/
/usr/share/man/man7/pcilib.7
/usr/share/man/man7/
/usr/share/man/man5/pci.ids.5
/usr/share/man/man5/
/usr/share/man/
/usr/share/hwdata/pci.ids.gz
/usr/share/hwdata/
/usr/share/
/usr/lib/pkgconfig/libpci.pc
/usr/lib/pkgconfig/
/usr/lib/libpci.so
/usr/lib/libpci.a
/usr/lib/
/usr/include/pci/types.h
/usr/include/pci/pci.h
/usr/include/pci/header.h
/usr/include/pci/config.h
/usr/include/pci/
/usr/include/
/usr/bin/update-pciids
/usr/bin/setpci
/usr/bin/
/usr/
```

## Existing package

- [x] I am the maintainer of this package.
