### PR TITLE
pciutils: fix building shared libraries

### DIFF
--- a/community/pciutils/build
+++ b/community/pciutils/build
@@ -11,7 +11,8 @@ mk() {
         "$@"
 }
 
-mk
 mk SHARED=yes
-mk DESTDIR="$1" install    install-lib
-mk DESTDIR="$1" SHARED=yes install-lib
+mk SHARED=yes DESTDIR="$1" install
+
+mk -B
+install -Dm644 lib/libpci.a "$1/usr/lib/libpci.a"


### PR DESCRIPTION
Closes #1280 

## Installed manifest of package

(`kiss manifest <pkg>`)

```
/var/db/kiss/installed/pciutils/version
/var/db/kiss/installed/pciutils/sources
/var/db/kiss/installed/pciutils/manifest
/var/db/kiss/installed/pciutils/depends
/var/db/kiss/installed/pciutils/checksums
/var/db/kiss/installed/pciutils/build
/var/db/kiss/installed/pciutils/
/var/db/kiss/installed/
/var/db/kiss/
/var/db/
/var/
/usr/share/man/man8/update-pciids.8
/usr/share/man/man8/setpci.8
/usr/share/man/man8/lspci.8
/usr/share/man/man8/
/usr/share/man/man7/pcilib.7
/usr/share/man/man7/
/usr/share/man/man5/pci.ids.5
/usr/share/man/man5/
/usr/share/man/
/usr/share/hwdata/pci.ids.gz
/usr/share/hwdata/
/usr/share/
/usr/lib/libpci.so.3.7.0
/usr/lib/libpci.so.3
/usr/lib/libpci.a
/usr/lib/
/usr/bin/update-pciids
/usr/bin/setpci
/usr/bin/lspci
/usr/bin/
/usr/
```

## Existing package

- [x] I am the maintainer of this package.
