### PR TITLE
minisign: add pkgconf as an explicit make dep

### DIFF
--- a/community/minisign/depends
+++ b/community/minisign/depends
@@ -1,2 +1,3 @@
-cmake make
+cmake   make
 libsodium
+pkgconf make


### PR DESCRIPTION
Required by minisign's cmake build script.

## Installed manifest of package

No difference.

## Existing package

- [x] I am the maintainer of this package.