### PR TITLE
libtorrent: Add depends

### DIFF
--- a/community/libtorrent/depends
+++ b/community/libtorrent/depends
@@ -1,0 +1,1 @@
+pkgconf make


### PR DESCRIPTION
Add build-time dependency on pkgconf, as this is no longer in core.
This is in relation to issue #1311 

## Existing package

- [x] I am the maintainer of this package.
