### PR TITLE
Cups filters: build and dependencies modified

### DIFF
--- a/community/cups-filters/build
+++ b/community/cups-filters/build
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 # Disable check for TTF font. 
-sed -i 's/as_fn_error.*Requested font/: "/' configure
+sed -i 's/as_fn_error.*font file/: "/' configure
 
 ./configure  \
     --prefix=/usr \

--- a/community/cups-filters/depends
+++ b/community/cups-filters/depends
@@ -3,5 +3,6 @@ freetype-harfbuzz
 ghostscript
 glib
 lcms make
+pkgconf make
 poppler
 qpdf


### PR DESCRIPTION
This PR fixes to issues:

- A fix were integrated in the `build` file, but it didn't work anymore (issue https://github.com/kisslinux/community/issues/1350).
- `pkgconf` is now added has a build dependency (issue https://github.com/kisslinux/community/issues/1311)

## Existing package

- [x] I am the maintainer of this package.
