### PR TITLE
w3m: add pkgconf as make dependency

### DIFF
--- a/community/w3m/depends
+++ b/community/w3m/depends
@@ -1,1 +1,2 @@
 gc
+pkgconf make


### PR DESCRIPTION
## Existing package

- [X] I am the maintainer of this package.

Added `pkgconf` as a make dependency per issue #1311.

On a side note, I noticed on Repology the version changed to 0.5.3pl38 (from 0.5.3). I looked at the source (https://github.com/tats/w3m) and on Repology and believe this to be the same release currently used. It looks like only OpenBSD is using this version name currently.
Should I bump the version so that it shows up as up-to-date on Repology or leave it as-is?