### PR TITLE
qt5-webchannel: perl is a make depend

### DIFF
--- a/community/qt5-webchannel/depends
+++ b/community/qt5-webchannel/depends
@@ -1,1 +1,2 @@
+perl make
 qt5-declarative


### PR DESCRIPTION
`qt5-webchannel` has a `perl` dep that slipped through the cracks.
## Existing package

- [x] I am the maintainer of this package.
