### PR TITLE
irssi: remove libgcrypt dependency

### DIFF
--- a/community/irssi/build
+++ b/community/irssi/build
@@ -5,6 +5,7 @@
     --sysconfdir=/etc \
     --mandir=/usr/share/man \
     --with-perl=module \
+    --with-otr=no \
     --with-proxy \
     --enable-true-color
 

--- a/community/irssi/depends
+++ b/community/irssi/depends
@@ -1,5 +1,4 @@
 glib
-libgcrypt
 libressl
 ncurses
 perl


### PR DESCRIPTION
Related to #1429.

## Installed manifest of package

Irrelevant.

## Existing package

- [x] I am the maintainer of this package.
