### PR TITLE
icu: disable ccache to fix clang issue

### DIFF
--- a/community/icu/build
+++ b/community/icu/build
@@ -1,5 +1,8 @@
 #!/bin/sh -e
 
+export CC="${CC:-/usr/bin/cc}"
+export CXX="${CXX:-/usr/bin/c++}"
+
 source/configure \
     --prefix=/usr \
     --sbindir=/usr/bin

--- a/community/icu/build
+++ b/community/icu/build
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+# ccache is causing the issue to expect clang instead of gcc.
+# Just disable it.
 export CC="${CC:-/usr/bin/cc}"
 export CXX="${CXX:-/usr/bin/c++}"
 


### PR DESCRIPTION
`ccache` cause trouble to build `icu` because it is somehow
looking for `clang`. Just disable ccache to fix the issue.
Fix for #1670

## Existing package

- [x] I am the maintainer of this package.
